### PR TITLE
fix: fatal error because of incompatible signature of insert_event_en…

### DIFF
--- a/classes/log/store.php
+++ b/classes/log/store.php
@@ -70,7 +70,7 @@ class store implements log_writer {
      *
      * @param array $evententries raw event data
      */
-    protected function insert_event_entries(array $evententries) {
+    protected function insert_event_entries($evententries) {
         (new trax_controller())->process_events($evententries);
     }
 

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2020060901;
+$plugin->version = 2023041900;
 $plugin->requires = 2020060900;
 $plugin->component = 'logstore_trax';
 


### PR DESCRIPTION
Without this fix, I'm getting the following error in PHP 8.1.18 in Moodle 4.1.2:

> Fatal error: Declaration of logstore_trax\log\store::insert_event_entries(array $evententries) must be compatible with tool_log\helper\buffered_writer::insert_event_entries($evententries) in /var/www/html/admin/tool/log/store/trax/classes/log/store.php on line 73

I'm a bit confused why the error didn't occur in PHP 7.4.33 for me, but according to https://github.com/moodle/moodle/blob/9766906cc59de845e5006194187d592c62bffbe0/admin/tool/log/classes/helper/buffered_writer.php#L114 and https://github.com/moodle/moodle/blob/b71f01981a5940f9aabc297bc6f97a31d2bda370/admin/tool/log/classes/helper/buffered_writer.php#L114 the signature of `insert_event_entries` is without the `array` keyword.