### PR TITLE
improve: use passwordunmask instead of configtext for password fields

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -55,7 +55,7 @@ if ($hassiteconfig) {
     ));
 
     // Password.
-    $settings->add(new admin_setting_configtext(
+    $settings->add(new admin_setting_configpasswordunmask(
         'logstore_trax/lrs_password',
         new lang_string('lrs_password', 'logstore_trax'),
         new lang_string('lrs_password_help', 'logstore_trax'),
@@ -91,7 +91,7 @@ if ($hassiteconfig) {
     ));
 
     // Password.
-    $settings->add(new admin_setting_configtext(
+    $settings->add(new admin_setting_configpasswordunmask(
         'logstore_trax/lrs2_password',
         new lang_string('lrs_password', 'logstore_trax'),
         new lang_string('lrs_password_help', 'logstore_trax'),

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2023041900;
+$plugin->version = 2023042500;
 $plugin->requires = 2020060900;
 $plugin->component = 'logstore_trax';
 


### PR DESCRIPTION
Typically, password fields should be masked. This patch changes the field type for the passwords from `configtext` to `configpasswordunmask`.