### PR TITLE
fix: only json_decode if the response is a json

### DIFF
--- a/classes/src/client.php
+++ b/classes/src/client.php
@@ -281,7 +281,11 @@ class client {
 
         // Body.
         if ($res->code == 200) {
-            $res->content = json_decode($guzzleresponse->getBody());
+            if (strpos($guzzleresponse->getHeaderLine('Content-Type'), 'application/json') !== false) {
+                $res->content = json_decode($guzzleresponse->getBody());
+            } else {
+                $res->content = (string)$guzzleresponse->getBody();
+           }
         }
 
         // Headers.

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2023042501;
+$plugin->version = 2025030500;
 $plugin->requires = 2020060900;
 $plugin->component = 'logstore_trax';
 


### PR DESCRIPTION
If a state is requested, which respond with a non json string, it cannot be decoded. This must be prevented so that $res->content is not null