### PR TITLE
fix: division by 0 for user grading

### DIFF
--- a/classes/src/statements/core/user_graded.php
+++ b/classes/src/statements/core/user_graded.php
@@ -158,7 +158,7 @@ class user_graded extends base_statement {
         if ($max > $min) {
             $result['score']['min'] = round($min, 2);
             $result['score']['max'] = round($max, 2);
-            $result['score']['scaled'] = ($raw - $min) / ($max - $min);
+            $result['score']['scaled'] = round(($raw - $min) / ($max - $min), 2);
         }
 
         if (!is_null($passed)) {

--- a/classes/src/statements/core/user_graded.php
+++ b/classes/src/statements/core/user_graded.php
@@ -149,16 +149,18 @@ class user_graded extends base_statement {
             $passed = $raw >= floatval($gradeitem->gradepass);
         }
 
-        // Define the result.
-        $scaled = ($raw - $min) / ($max - $min);
         $result = [
             'score' => [
-                'raw' => round($raw, 2),
-                'min' => round($min, 2),
-                'max' => round($max, 2),
-                'scaled' => round($scaled, 2)
+                'raw' => round($raw, 2)
             ]
         ];
+
+        if ($max > $min) {
+            $result['score']['min'] = round($min, 2);
+            $result['score']['max'] = round($max, 2);
+            $result['score']['scaled'] = ($raw - $min) / ($max - $min);
+        }
+
         if (!is_null($passed)) {
             $result['success'] = $passed;
         }

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2025060400;
+$plugin->version = 2026041600;
 $plugin->requires = 2020060900;
 $plugin->component = 'logstore_trax';
 


### PR DESCRIPTION
Fixed the "Division by zero" issue as discussed in #24

@sfraysse When accepting the fix, please squash the commits - thank you very much.